### PR TITLE
Allow guzzle version > 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Validate Yubikey OTP in Symfony2",
   "require": {
     "php": ">=5.3.2",
-    "guzzlehttp/guzzle": "5.2.*"
+    "guzzlehttp/guzzle": ">=5.2.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
My project has a dependency on a earlier version of guzzle (5.3). As your project is also working with this version, I suggest you update your dependency requirement.
Thanks.
