### PR TITLE
Compatibility with Guzzle 6.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add to config.yml
 ```yml
     pm_yubikey_otp:
       server:
-        host: https://api2.yubico.com/wsapi/2.0/
+        uri: https://api2.yubico.com/wsapi/2.0/
         client_id: YourClientId
         client_secret: YourApiKey
 ```

--- a/Services/ValidationService.php
+++ b/Services/ValidationService.php
@@ -124,7 +124,7 @@ class ValidationService
         /**
          * Create Guzzle Request
          */
-        $guzzle = new Client(['base_url' => $this->config['server']['uri']]);
+        $guzzle = new Client(['base_url' => $this->config['server']['uri'], 'base_uri' => $this->config['server']['uri']]);
 
         $response = $guzzle->get($this->getVerifyUrl($oneTimePassword));
         $responseBody = $response->getBody()->getContents();


### PR DESCRIPTION
Guzzle 6.\* uses base_uri instead of base_url + fix small typo in readme
